### PR TITLE
Build and run with flakes for better reproducibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
 # Convert Nix CycloneDX
 
 This converts a Nix derivation to a CycloneDX SBoM
+
+## Run with nix2.4 (with flakes)
+```
+nix show-derivation .# --recursive | nix run .#
+```

--- a/cyclonedx.go
+++ b/cyclonedx.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"regexp"
+	"sort"
 	"strings"
 )
 
@@ -48,6 +49,12 @@ type cycloneHashes struct {
 }
 
 func NewCycloneFromNix(n *nix) (*cycloneDx, error) {
+	keys := make([]string, 0, len(*n))
+	for k := range *n {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
 	var err error
 	c := cycloneDx{
 		BomFormat:   "CycloneDX",
@@ -57,7 +64,8 @@ func NewCycloneFromNix(n *nix) (*cycloneDx, error) {
 	}
 	verRe := regexp.MustCompile("^.*-([0-9\\.]+)(\\.tar\\.gz|\\.tar\\.bz2|)$")
 
-	for _, entry := range *n {
+	for _, key := range keys {
+		entry := (*n)[key]
 		if entry.Env == nil {
 			continue
 		}

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,24 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1633791597,
+        "narHash": "sha256-HzpxqTEnqsjkKWfW87kSI3WVizYjUMQeUjSIm3b5I0Y=",
+        "path": "/nix/store/fjdfm9jz85sr5a8fnmp4d10i1cf95ncp-source",
+        "rev": "9bf75dd50b7b6d3ce6aaf6563db95f41438b9bdb",
+        "type": "path"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,16 @@
+{
+  description = "convert-nix-cyclondx uses nix show-derivation --recursive to CycloneDX";
+
+  outputs = { self, nixpkgs }: {
+
+    packages.x86_64-linux.convert-nix-cyclonedx = nixpkgs.legacyPackages.x86_64-linux.buildGoModule {
+      pname = "convert-nix-cyclonedx";
+      version = "0.0.0";
+      src = self;
+      vendorSha256 = "sha256-pQpattmS9VmO3ZIQUFn66az8GSmB4IvYhTTCFn6SUmo=";
+    };
+
+    defaultPackage.x86_64-linux = self.packages.x86_64-linux.convert-nix-cyclonedx;
+
+  };
+}


### PR DESCRIPTION
This might help. Sadly the CycloneDX serialization itself is not deterministic, the ordering changes. This is a golang/conversion problem. Ordering the output via the keys rather than by the order a `range *n` provides should be better. But i'm not at all familiar with the CycloneDX spec to know if there is a proper order (topological?)